### PR TITLE
Clone repos in house

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 requests==2.22.0
-GitPython==3.0.3
 PyYaml==5.2
 termcolor==1.1.0

--- a/src/git_interactions.py
+++ b/src/git_interactions.py
@@ -13,14 +13,11 @@ def clone_repo(cloneURL):
     Returns:
         string -- the current working directory path
     """
-    # Getting repo name:
-    cloneURL_paths = cloneURL.split("/")
-    repo_name = cloneURL_paths[-1].strip(".git")
     # Cloning repo:
     if "repos" not in os.listdir():
         os.mkdir("repos")
     os.chdir("repos")
-    git.Repo.clone_from(cloneURL, repo_name)
+    call(["git", "clone", cloneURL], stdout=subprocess.PIPE)
     os.chdir("..")
     return os.listdir("repos")
 

--- a/src/git_interactions.py
+++ b/src/git_interactions.py
@@ -1,7 +1,7 @@
 import os
 import git
 import requests
-from subprocess import call
+import subprocess as sp
 
 
 def clone_repo(cloneURL):
@@ -17,7 +17,7 @@ def clone_repo(cloneURL):
     if "repos" not in os.listdir():
         os.mkdir("repos")
     os.chdir("repos")
-    call(["git", "clone", cloneURL], stdout=subprocess.PIPE)
+    sp.call(["git", "clone", cloneURL], stdout=sp.PIPE)
     os.chdir("..")
     return os.listdir("repos")
 

--- a/src/git_interactions.py
+++ b/src/git_interactions.py
@@ -1,5 +1,4 @@
 import os
-import git
 import requests
 import subprocess as sp
 


### PR DESCRIPTION
Clone repos with standard python instead of relying on a package. Replaced the GitPython package. 

This PR resolves #10  